### PR TITLE
READMEにDB設計を記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,14 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Things you may want to cover:
 |Column|Type|Options|
 |------|----|-------|
 |text|text|null: false|
+|image|text|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,31 @@ Things you may want to cover:
 
 * ...
 
+
+## usersテーブル
+
+|column|type|options|
+|------|----|-------|
+|name|string|null: false|
+|email|string|null: false, unique: true|
+|password|string|null: false|
+
+### Association
+- has_many :groups_users
+- has_many :groups, through: :groups_users
+- has_many :comments
+
+## groupsテーブル
+
+|column|type|options|
+|------|----|-------|
+|name|string|null: false|
+
+### Association
+- has_many :groups_users
+- has_many :users, through: :groups_users
+- has_many :comments
+
 ## groups_usersテーブル
 
 |Column|Type|Options|
@@ -33,3 +58,15 @@ Things you may want to cover:
 ### Association
 - belongs_to :group
 - belongs_to :user
+
+## commentsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|text|text|null: false|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :user
+- belongs_to :group

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Things you may want to cover:
 
 |column|type|options|
 |------|----|-------|
-|name|string|null: false|
+|name|string|null: false, unique: true|
 
 ### Association
 - has_many :groups_users
@@ -63,7 +63,7 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|text|text|null: false|
+|text|text|
 |image|text|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|


### PR DESCRIPTION
# what
readmeにdb設計を記載した。
railsのreadme.mdに以下のテーブルを記載
　usersテーブル、groupsテーブル、groups_usersテーブル、commentsテーブル

# why
これから作成するDBを文書化し、イメージするため。