### PR TITLE
スクロールバーの追加

### DIFF
--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -54,6 +54,7 @@
   &__group-list {
     background-color: #2f3e51;
     height: calc(100vh - 100px);
+    overflow: scroll;
     .single-group {
       padding: 20px 20px 40px;
       .group__link {


### PR DESCRIPTION
# WHAT
##### サイドバーのグループリストにスクロールバーを追加
- スクロールバーを追加していなかったため追加
### すでに作成されたトピックブランチを引っ張ってきて、それに編集して更新していいかわからんかったので、新しくこのブランチ作って、作業をした

# WHY
- スクロールバーがないと、ブラウザの表示から溢れた時にビュー崩れが起きるため